### PR TITLE
Make some Embed "media" fields optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ I prefer indentation with tabs for improved accessibility. But, I'd rather you u
 
 By participating in this project you agree to abide by the [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
 
-[build status]: https://github.com/mattmassicotte/ATResolve/actions
-[build status badge]: https://github.com/mattmassicotte/ATResolve/workflows/CI/badge.svg
+[build status]: https://github.com/mattmassicotte/ATAT/actions
+[build status badge]: https://github.com/mattmassicotte/ATAT/workflows/CI/badge.svg
 [matrix]: https://matrix.to/#/%23chimehq%3Amatrix.org
 [matrix badge]: https://img.shields.io/matrix/chimehq%3Amatrix.org?label=Matrix
 [discord]: https://discord.gg/esFpX6sErJ

--- a/Sources/ATAT/Embed.swift
+++ b/Sources/ATAT/Embed.swift
@@ -87,7 +87,7 @@ extension Bsky.Embed {
 	public struct Images: Decodable, Hashable, Sendable {
 		public struct Image: Decodable, Hashable, Sendable {
 			public let alt: String
-			public let aspectRatio: AspectRatio
+			public let aspectRatio: AspectRatio?
 			public let image: Bsky.Blob
 		}
 		
@@ -98,7 +98,7 @@ extension Bsky.Embed {
 extension Bsky.Embed.Images {
 	public struct ViewImage: Decodable, Hashable, Sendable {
 		public let alt: String
-		public let aspectRatio: Bsky.Embed.AspectRatio
+		public let aspectRatio: Bsky.Embed.AspectRatio?
 		public let fullsize: String
 		public let thumb: String
 	}
@@ -110,7 +110,7 @@ extension Bsky.Embed.Images {
 
 extension Bsky.Embed {
 	public struct Video: Decodable, Hashable, Sendable {
-		public let aspectRatio: Bsky.Embed.AspectRatio
+		public let aspectRatio: Bsky.Embed.AspectRatio?
 		public let video: Bsky.Blob
 	}
 }
@@ -119,7 +119,7 @@ extension Bsky.Embed.Video {
 	public struct View: Decodable, Hashable, Sendable {
 		public let cid: ATProtoCID
 		public let playlist: String
-		public let thumbnail: String
-		public let aspectRatio: Bsky.Embed.AspectRatio
+		public let thumbnail: String?
+		public let aspectRatio: Bsky.Embed.AspectRatio?
 	}
 }

--- a/Tests/ATATTests/PostTests.swift
+++ b/Tests/ATATTests/PostTests.swift
@@ -100,9 +100,10 @@ struct PostTests {
 		
 		#expect(images.images.count == 1)
 		let image = try #require(images.images.first)
+		let imageAspectRatio = try #require(image.aspectRatio)
 		
-		#expect(image.aspectRatio.height == 1500)
-		#expect(image.aspectRatio.width == 1999)
+		#expect(imageAspectRatio.height == 1500)
+		#expect(imageAspectRatio.width == 1999)
 		#expect(image.image.mimeType == "image/jpeg")
 		#expect(image.image.size == 922545)
 		
@@ -110,9 +111,10 @@ struct PostTests {
 		
 		#expect(imagesView.images.count == 1)
 		let imageView = try #require(imagesView.images.first)
-
-		#expect(imageView.aspectRatio.height == 1500)
-		#expect(imageView.aspectRatio.width == 1999)
+		let imageViewAspectRatio = try #require(imageView.aspectRatio)
+		
+		#expect(imageViewAspectRatio.height == 1500)
+		#expect(imageViewAspectRatio.width == 1999)
 		#expect(imageView.fullsize == "https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:z7ja7uhcr5is6uqmnsjyn3k7/bafkreicjr5ezdgwv6z4zcxv2egqjmaox6ocplsrhvubmmfqyuh6dybhfma@jpeg")
 	}
 	
@@ -176,10 +178,11 @@ struct PostTests {
 		#expect(embedVideo.video.mimeType == "video/mp4")
 		
 		guard case let .embedVideoView(embedVideoView) = post.embed else { fatalError() }
+		let videoAspectRatio = try #require(embedVideoView.aspectRatio)
 		
 		#expect(embedVideoView.playlist == "https://video.bsky.app/watch/did%3Aplc%3Al7mosai5i2u562b5qbosw6c7/bafkreic3uqlah5pnqzq4tx2r5cg6kyj2uziq4jn4uatuwdhvl33sx2qkgm/playlist.m3u8")
 		#expect(embedVideoView.thumbnail == "https://video.bsky.app/watch/did%3Aplc%3Al7mosai5i2u562b5qbosw6c7/bafkreic3uqlah5pnqzq4tx2r5cg6kyj2uziq4jn4uatuwdhvl33sx2qkgm/thumbnail.jpg")
-		#expect(embedVideoView.aspectRatio.height == 1920)
-		#expect(embedVideoView.aspectRatio.width == 1920)
+		#expect(videoAspectRatio.height == 1920)
+		#expect(videoAspectRatio.width == 1920)
 	}
 }


### PR DESCRIPTION
## Description

Running the project locally, I realized some fields were not being found when decoded by Codable. Then, I checked the Bluesky documentation and noticed some fields were not mandatory. This PR aims to fix them.

Documentation for
1. [Embed Images](https://github.com/bluesky-social/atproto/blob/f90eedc865136f50a9daee72c52b275d26310aa3/lexicons/app/bsky/embed/images.json)
2. [Embed Videos](https://github.com/bluesky-social/atproto/blob/f90eedc865136f50a9daee72c52b275d26310aa3/lexicons/app/bsky/embed/video.json)

###  Error

```
failed to load timeline: 
CompositeSocialService.BlueskyService, 
keyNotFound(
    CodingKeys(stringValue: "aspectRatio", intValue: nil), 
    Swift.DecodingError.Context(
        codingPath: [
            CodingKeys(stringValue: "feed", intValue: nil), 
            _CodingKey(stringValue: "Index 16", intValue: 16), 
            CodingKeys(stringValue: "post", intValue: nil), 
            CodingKeys(stringValue: "record", intValue: nil), 
            CodingKeys(stringValue: "embed", intValue: nil), 
            CodingKeys(stringValue: "images", intValue: nil), 
            _CodingKey(stringValue: "Index 0", intValue: 0)
        ], 
        debugDescription: "No value associated with key CodingKeys(stringValue: \"aspectRatio\", intValue: nil) (\"aspectRatio\").", 
        underlyingError: nil
    )
)
```