### PR TITLE
Helper function to parse URI into components

### DIFF
--- a/Sources/ATAT/Bsky.swift
+++ b/Sources/ATAT/Bsky.swift
@@ -17,7 +17,9 @@ public struct Bsky {
 	}
 	
 	public enum NSID: String, Codable, Hashable, Sendable {
-		case feedLike = "app.bsky.feed.like"
+		case feedLike 		= "app.bsky.feed.like"
+		case feedPost 		= "app.bsky.feed.post"
+		case feedTimeline 	= "app.bsky.feed.getTimeline"
 	}
 }
 

--- a/Sources/ATAT/Feed+Extensions.swift
+++ b/Sources/ATAT/Feed+Extensions.swift
@@ -16,6 +16,24 @@ extension Bsky.Feed.PostView {
 		
 		return postRecord.createdAt
 	}
+
+	// Helper function to parse URI into components
+	func parseURI(_ uri: String) -> [String: String] {
+		let components = uri
+			.trimmingCharacters(in: .whitespacesAndNewlines)
+			.split(separator: "/", omittingEmptySubsequences: false)
+			.map { String($0) }
+
+		guard components.count >= 5 else {
+			return [:]
+		}
+
+		return [
+			"repo": components[2],
+			"collection": components[3],
+			"rkey": components[4]
+		]
+	}
 }
 
 extension Bsky.Feed.FeedViewPost {


### PR DESCRIPTION
Parsing a URI is needed when performing operations such as fetching or deleting a specific record, for two examples. I added this method to "extension Bsky.Feed.PostView". I'm not sure if that's the most appropriate place but I'll leave that to you Matt. 

I should also say that as of last week I have opted to abandon my attempt at converting my project to use the AT Protocol. I have been working strictly on ATProto for the last 5 months and have made only moderate progress. The decision wasn't easy, but after spending a solid 12 hours over two days just trying to get "likes" to work, then reading about the complexities of OAuth with ATProto I made the call to leave it behind. I am certainly not an advanced developer, but I'm not a beginner either. Your initial assumptions on the complexities were spot on I believe. The time I've spent versus the progress and benefit have not panned out. Perhaps I'll revisit the idea in a year if the protocol is more approachable for mere mortals such as me.